### PR TITLE
Add interactive buffer pick mode

### DIFF
--- a/buffers.kak
+++ b/buffers.kak
@@ -77,7 +77,6 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
     keys=" $kak_opt_buffer_keys"
     num_keys=$(($(echo "$kak_opt_buffer_keys" | wc -m) - 1))
     eval "set -- $kak_opt_buffers_info"
-    echo "echo -debug \"buffers info: $kak_opt_buffers_info keys: '$kak_opt_buffer_keys' num_keys: $num_keys\""
     while [ "$1" ]; do
       # limit lists too big
       index=$(($index + 1))
@@ -87,7 +86,6 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
 
       name=${1%_*}
       modified=${1##*_}
-      echo "echo -debug \"index: $index name: $name modified: $modified\""
       if [ "$name" = "$kak_bufname" ]; then
         echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \"> $name $(if [ "$modified" = true ]; then echo "[+]"; fi)\""
       elif [ "$name" = "$kak_opt_alt_bufname" ]; then

--- a/buffers.kak
+++ b/buffers.kak
@@ -4,6 +4,9 @@ declare-option -hidden str-list buffers_info
 
 declare-option int buffers_total
 
+# keys to use for buffer picking
+declare-option str buffer_keys "1234567890qwertyuiopasdfghjklzxcvbnm"
+
 # used to handle [+] (modified) symbol in list
 define-command -hidden refresh-buffers-info %{
   set-option global buffers_info
@@ -63,6 +66,40 @@ define-command info-buffers -docstring 'populate an info box with a numbered buf
     done
     printf ^\\n
   }
+}
+
+declare-user-mode pick-buffers
+define-command pick-buffers -docstring 'enter buffer pick mode' %{
+  refresh-buffers-info
+  unmap global pick-buffers
+  evaluate-commands %sh{
+    index=0
+    keys=" $kak_opt_buffer_keys"
+    num_keys=$(($(echo "$kak_opt_buffer_keys" | wc -m) - 1))
+    eval "set -- $kak_opt_buffers_info"
+    echo "echo -debug \"buffers info: $kak_opt_buffers_info keys: '$kak_opt_buffer_keys' num_keys: $num_keys\""
+    while [ "$1" ]; do
+      # limit lists too big
+      index=$(($index + 1))
+      if [ "$index" -gt "$num_keys" ]; then
+        break
+      fi
+
+      name=${1%_*}
+      modified=${1##*_}
+      echo "echo -debug \"index: $index name: $name modified: $modified\""
+      if [ "$name" = "$kak_bufname" ]; then
+        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \"> $name $(if [ "$modified" = true ]; then echo "[+]"; fi)\""
+      elif [ "$name" = "$kak_opt_alt_bufname" ]; then
+        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \"# $name $(if [ "$modified" = true ]; then echo "[+]"; fi)\""
+      else
+        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \"  $name $(if [ "$modified" = true ]; then echo "[+]"; fi)\""
+      fi
+
+      shift
+    done
+  }
+  enter-user-mode pick-buffers
 }
 
 define-command buffer-first -docstring 'move to the first buffer in the list' 'buffer-by-index 1'


### PR DESCRIPTION
This adds a command which enables interactive buffer selection, by dynamically creating a user mode from the buffer info.

The reason for adding this is that I sometimes do `:info-buffers`, but when I enter the command to switch to the buffer I want, I'll have forgotten which buffer I actually wanted to switch to. In the buffer pick mode, one can directly switch to a buffer while the information is still displayed on the screen.

Some notes:
- The keys are a bit subjective. This seemed like a logical order to me. The initial keys are also the same as those used for the buffer info, so that is probably easy to remember.
- There is unfortunately no clean way to show that the key limit has been reached. The limit could of course be raised by adding uppercase and other keys, but I don't think it is common to reach this limit anyway. Perhaps a dummy mapping could be added to display that the limit has been reached, or some form of pagination could be added.
- It might be nice to integrate this with the existing buffer mode, but the obvious keys have already been taken.
- The display style is a bit different than the info box. It might be nice to unify this a little.