### PR TITLE
refactor pick-buffers

### DIFF
--- a/buffers.kak
+++ b/buffers.kak
@@ -81,9 +81,16 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
   refresh-buffers-info
   unmap global pick-buffers
   evaluate-commands %sh{
+    docstring() {
+      if [ "$1" = true ]; then
+        printf "%s+ %s" "$2" "$3"
+      else
+        printf "%s  %s" "$2" "$3"
+      fi
+    }
     index=0
     keys=" $kak_opt_buffer_keys"
-    num_keys=$(($(echo "$kak_opt_buffer_keys" | wc -m) - 1))
+    num_keys=${#kak_opt_buffer_keys}
     eval "set -- $kak_quoted_opt_buffers_info"
     while [ "$1" ]; do
       # limit lists too big
@@ -95,11 +102,11 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
       name=${1%_*}
       modified=${1##*_}
       if [ "$name" = "$kak_bufname" ]; then
-        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \">$(if [ "$modified" = true ]; then echo "+"; else echo " "; fi) $name\""
+        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '>' "$name")"
       elif [ "$name" = "$kak_opt_alt_bufname" ]; then
-        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \"#$(if [ "$modified" = true ]; then echo "+"; else echo " "; fi) $name\""
+        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '#' "$name")"
       else
-        echo "map global pick-buffers ${keys:$index:1} :buffer-by-index<space>$index<ret> -docstring \" $(if [ "$modified" = true ]; then echo "+"; else echo " "; fi) $name\""
+        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified ':' "$name")"
       fi
 
       shift

--- a/buffers.kak
+++ b/buffers.kak
@@ -42,7 +42,7 @@ define-command info-buffers -docstring 'populate an info box with a numbered buf
     eval "set -- $kak_quoted_opt_buffers_info"
     while [ "$1" ]; do
       # limit lists too big
-      index=$(($index + 1))
+      index=$((index + 1))
       if [ "$index" -gt "$kak_opt_max_list_buffers" ]; then
         printf '  …'
         break
@@ -94,7 +94,7 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
     eval "set -- $kak_quoted_opt_buffers_info"
     while [ "$1" ]; do
       # limit lists too big
-      index=$(($index + 1))
+      index=$((index + 1))
       if [ "$index" -gt "$num_keys" ]; then
         break
       fi
@@ -128,7 +128,7 @@ define-command -hidden -params 1 buffer-by-index %{
     index=0
     eval "set -- $kak_quoted_opt_buffers_info"
     while [ "$1" ]; do
-      index=$(($index+1))
+      index=$((index+1))
       name=${1%_*}
       if [ $index = $target ]; then
         printf "buffer '$name'"

--- a/buffers.kak
+++ b/buffers.kak
@@ -102,11 +102,11 @@ define-command pick-buffers -docstring 'enter buffer pick mode' %{
       name=${1%_*}
       modified=${1##*_}
       if [ "$name" = "$kak_bufname" ]; then
-        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '>' "$name")"
+        printf "map global pick-buffers %s ': buffer-by-index %s<ret>' -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '>' "$name")"
       elif [ "$name" = "$kak_opt_alt_bufname" ]; then
-        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '#' "$name")"
+        printf "map global pick-buffers %s ': buffer-by-index %s<ret>' -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified '#' "$name")"
       else
-        printf "map global pick-buffers %s :<space>buffer-by-index<space>%s<ret> -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified ':' "$name")"
+        printf "map global pick-buffers %s ': buffer-by-index %s<ret>' -docstring '%s'\n" ${keys:$index:1} $index "$(docstring $modified ':' "$name")"
       fi
 
       shift


### PR DESCRIPTION
 - moved docstring generation to func
 - replaced `wc -m` by builtin shell len
 - prefix clear buffers with `:` rather than space, as `-docstring` doesn't accept first space for some reason