### PR TITLE
Add configurable buffer_alternate_command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With `buffer-first-modified`, jump to the first modified buffer.
 
 To delete all buffers except the current one, use `buffer-only` or the more destructive `buffer-only-force` version.
 You can also delete all buffers except the ones in the same dir as the current buffer with `buffer-only-directory`.
+
 ## User mode
 
 All these commands are grouped in a dedicated `buffers` user-mode.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ With `buffer-first-modified`, jump to the first modified buffer.
 To delete all buffers except the current one, use `buffer-only` or the more destructive `buffer-only-force` version.
 You can also delete all buffers except the ones in the same dir as the current buffer with `buffer-only-directory`.
 
+To use a custom command for switching to the alternate buffer, set the `buffer_alternate_command` option:
+```
+# an 'alt' alias is already set by multiple filetype rc scripts
+set global buffer_alternate_command 'alt'
+```
+If you do not set this option, or if the provided command fails, then `ga` will be used to switch to the alternate buffer.
+
 ## User mode
 
 All these commands are grouped in a dedicated `buffers` user-mode.

--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ With `buffer-first-modified`, jump to the first modified buffer.
 
 To delete all buffers except the current one, use `buffer-only` or the more destructive `buffer-only-force` version.
 You can also delete all buffers except the ones in the same dir as the current buffer with `buffer-only-directory`.
-
-To use a custom command for switching to the alternate buffer, set the `buffer_alternate_command` option:
-```
-# an 'alt' alias is already set by multiple filetype rc scripts
-set global buffer_alternate_command 'alt'
-```
-If you do not set this option, or if the provided command fails, then `ga` will be used to switch to the alternate buffer.
-
 ## User mode
 
 All these commands are grouped in a dedicated `buffers` user-mode.

--- a/buffers.kak
+++ b/buffers.kak
@@ -32,16 +32,12 @@ hook global WinDisplay .* %{
   set-option global current_bufname %val{bufname}
 }
 
-# A value of 'alt' is recommended, as this is an alias used by multiple filetype rc scripts.
-# NOTE: This is set by default to a command that's expected to fail in order to retain the original plugin behavior.
-# The guid suffix is trying to "guarantee" that it won't accidentally be a command someone might set.
-declare-option str buffer_alternate_command 'nosuchcommand_d1e3a0d4717a4c699eb0c275bbfccd36'
-define-command buffer-alternate -docstring 'open the alternate or previous file in a new buffer' %{
+define-command buffer-alternate -docstring 'open the alternate file in a new buffer' %{
     try %{
-        # attempt to execute a custom command specified by the `buffer_alternate_command` option
-        evaluate-commands %sh{printf "%s\n" "$kak_opt_buffer_alternate_command"}
+        # attempt to execute the `alt` command alias
+        evaluate-commands ': alt<ret>'
     } catch %{
-        # use 'ga' as the fallback/default behaviour
+        # use 'ga' as the fallback/default behavior
         execute-keys ga
     }
 }

--- a/buffers.kak
+++ b/buffers.kak
@@ -32,6 +32,20 @@ hook global WinDisplay .* %{
   set-option global current_bufname %val{bufname}
 }
 
+# A value of 'alt' is recommended, as this is an alias used by multiple filetype rc scripts.
+# NOTE: This is set by default to a command that's expected to fail in order to retain the original plugin behavior.
+# The guid suffix is trying to "guarantee" that it won't accidentally be a command someone might set.
+declare-option str buffer_alternate_command 'nosuchcommand_d1e3a0d4717a4c699eb0c275bbfccd36'
+define-command buffer-alternate -docstring 'open the alternate or previous file in a new buffer' %{
+    try %{
+        # attempt to execute a custom command specified by the `buffer_alternate_command` option
+        evaluate-commands %sh{printf "%s\n" "$kak_opt_buffer_alternate_command"}
+    } catch %{
+        # use 'ga' as the fallback/default behaviour
+        execute-keys ga
+    }
+}
+
 define-command info-buffers -docstring 'populate an info box with a numbered buffers list' %{
   refresh-buffers-info
   evaluate-commands %sh{
@@ -222,7 +236,7 @@ define-command edit-kakrc -docstring 'open kakrc in a new buffer' %{
 
 declare-user-mode buffers
 
-map global buffers a 'ga'                             -docstring 'alternate ↔'
+map global buffers a ': buffer-alternate<ret>'        -docstring 'alternate ↔'
 map global buffers b ': info-buffers<ret>'            -docstring 'info'
 map global buffers c ': edit-kakrc<ret>'              -docstring 'config'
 map global buffers d ': delete-buffer<ret>'           -docstring 'delete'

--- a/buffers.kak
+++ b/buffers.kak
@@ -35,10 +35,12 @@ hook global WinDisplay .* %{
 define-command buffer-alternate -docstring 'open the alternate file in a new buffer' %{
     try %{
         # attempt to execute the `alt` command alias
-        evaluate-commands ': alt<ret>'
+        alt
     } catch %{
         # use 'ga' as the fallback/default behavior
         execute-keys ga
+    } catch %{
+        fail 'no alternate file or buffer available'
     }
 }
 


### PR DESCRIPTION
The `buffers` user-mode provides the `a` key mapping to switch to an alternate buffer, but it is currently just a pass-through to `ga`.

This PR adds a configurable option for setting a custom command for switching to an alternate buffer. The intended use case is to provide a command to switch to a test or spec file as the alternate file, if one exists, rather than the previous buffer.

While looking through the filetype scripts bundled with Kakoune I noticed that more than one filetype script provides an alternate file command along with an 'alt' alias. I think it would be a good idea to simply attempt the 'alt' command alias as a default for the 'a' mapping, with `ga` as a fallback because it would Just Work for certain file types without changing the behavior for others. However, I went the route of leaving the default behavior unchanged and up to the user, while suggesting this in the README instead.